### PR TITLE
update compatibility with ESPHome 1.13.5

### DIFF
--- a/martin_jerry_mj_sd01_dimmer.yaml
+++ b/martin_jerry_mj_sd01_dimmer.yaml
@@ -226,7 +226,7 @@ interval:
     # https://esphome.io/guides/automations.html#interval
     then:
       - lambda: |-
-          auto dimmer_vals = id(dimmer).get_current_values();
+          auto dimmer_vals = id(dimmer).current_values;
           if (dimmer_vals.is_on()) {
             id(dimmer_lvl) = dimmer_vals.get_brightness();
             if (id(dimmer_lvl) > .19) { id(led2).turn_on(); }


### PR DESCRIPTION
Found warning while building .bin file. This PR fixes the issue.

In lambda function:

warning: 'esphome::light::LightColorValues esphome::light::LightState::get_current_values()' is deprecated (declared at src/esphome/components/light/light_state.h:207): get_current_values() is deprecated, please use .current_values instead. [-Wdeprecated-declarations]

auto dimmer_vals = dimmer->get_current_values();